### PR TITLE
Neo go compiler

### DIFF
--- a/docker-neo-go/Dockerfile
+++ b/docker-neo-go/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:alpine
+LABEL maintainers="anthdm,stevenjack"
+
+RUN apk update && apk add git make && rm -rf /var/cache/apk/*
+
+RUN mkdir -p /go/src/github.com/CityOfZion
+RUN mkdir -p /go/src/github.com/anthdm
+
+RUN git clone https://github.com/CityOfZion/neo-go /go/src/github.com/CityOfZion/neo-go
+RUN git clone https://github.com/anthdm/neo-go /go/src/github.com/anthdm/neo-go
+
+WORKDIR /go/src/github.com/CityOfZion/neo-go
+
+RUN go get -u github.com/golang/dep/cmd/dep
+RUN dep ensure
+
+ADD compile.sh /compile.sh
+RUN chmod u+x /compile.sh
+
+RUN make build
+
+ENTRYPOINT ["/compile.sh"]

--- a/docker-neo-go/Dockerfile
+++ b/docker-neo-go/Dockerfile
@@ -1,15 +1,14 @@
 FROM golang:alpine
 LABEL maintainers="anthdm,stevenjack"
+ENV APP_DIRECTORY /go/src/github.com/CityOfZion/neo-go
 
 RUN apk update && apk add git make && rm -rf /var/cache/apk/*
 
-RUN mkdir -p /go/src/github.com/CityOfZion
-RUN mkdir -p /go/src/github.com/anthdm
+RUN mkdir -p $APP_DIRECTORY
 
-RUN git clone https://github.com/CityOfZion/neo-go /go/src/github.com/CityOfZion/neo-go
-RUN git clone https://github.com/anthdm/neo-go /go/src/github.com/anthdm/neo-go
+RUN git clone https://github.com/CityOfZion/neo-go $APP_DIRECTORY
 
-WORKDIR /go/src/github.com/CityOfZion/neo-go
+WORKDIR $APP_DIRECTORY
 
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN dep ensure

--- a/docker-neo-go/README
+++ b/docker-neo-go/README
@@ -1,1 +1,0 @@
-waiting for go compiler support.

--- a/docker-neo-go/compile.sh
+++ b/docker-neo-go/compile.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+echo $COMPILECODE | base64 -d > /tmp/contract.go
+
+echo -n "{ \"output\": \""
+ ./bin/neo-go contract compile -i /tmp/contract.go -o /tmp/contract.avm > /tmp/output.txt 2> /tmp/output.err
+cat /tmp/output.txt /tmp/output.err
+cat /tmp/output.txt /tmp/output.err | base64 | tr -d '\n'
+echo -n "\", \"avm\": \""
+if [ -f /tmp/contract.avm ]; then
+   cat /tmp/contract.avm | xxd -p | base64 | tr -d '\n'
+fi
+echo -n "\", \"abi\":\""
+if [ -f /tmp/ccontract.abi.json ]; then
+   cat /tmp/ccontract.abi.json | base64 | tr -d '\n'
+fi
+echo "\"}"

--- a/docker-neo-go/compile.sh
+++ b/docker-neo-go/compile.sh
@@ -4,14 +4,13 @@ echo $COMPILECODE | base64 -d > /tmp/contract.go
 
 echo -n "{ \"output\": \""
  ./bin/neo-go contract compile -i /tmp/contract.go -o /tmp/contract.avm > /tmp/output.txt 2> /tmp/output.err
-cat /tmp/output.txt /tmp/output.err
 cat /tmp/output.txt /tmp/output.err | base64 | tr -d '\n'
 echo -n "\", \"avm\": \""
 if [ -f /tmp/contract.avm ]; then
    cat /tmp/contract.avm | xxd -p | base64 | tr -d '\n'
 fi
 echo -n "\", \"abi\":\""
-if [ -f /tmp/ccontract.abi.json ]; then
-   cat /tmp/ccontract.abi.json | base64 | tr -d '\n'
+if [ -f /tmp/contract.abi.json ]; then
+   cat /tmp/contract.abi.json | base64 | tr -d '\n'
 fi
 echo "\"}"


### PR DESCRIPTION
### Problem

There's no [neo-go](https://github.com/CityOfZion/neo-go) compiler support 😢.

### Solution

* Add `Dockerfile` for building `neo-go` binary to then allow compilation of `golang` contracts 😍.

Here's an example of a super simple :trollface: contract to test:

```go
package main

func Main() int {
	x := 10
	return x
}
```

### Notes

* In the future we'll have a pre-built container built on each tag of [neo-go](https://github.com/CityOfZion/neo-go),  however for the moment we'll manually build it.