### PR TITLE
Fix deploy gas fee

### DIFF
--- a/public/js/eco-scripts/eco_activity.js
+++ b/public/js/eco-scripts/eco_activity.js
@@ -28,7 +28,7 @@ function restoreDeployTX(txID) {
         var deployJsonParams = JSON.parse(vecRelayedTXs[txID].txParams);
         console.log(deployJsonParams);
         if (deployJsonParams.type === "deploy") {
-            $("#attachDeployGasFeeJS").val(deployJsonParams.mynetfee);
+            $("#attachDeployGasFeeJS").val(deployJsonParams.mynetfee.slice(0,10));
             $("#jsdeploy_name").val(deployJsonParams.contract_appname);
             $("#jsdeploy_desc").val(deployJsonParams.contract_description);
             $("#jsdeploy_email").val(deployJsonParams.contract_email);


### PR DESCRIPTION
Sometimes the GAS fee is set to a number with a really low decimal, which then leads to an error when deploying. This PR fixes that by truncating the number.