### PR TITLE
Remove "use param array" resetting

### DIFF
--- a/public/js/eco-scripts/abi_manager.js
+++ b/public/js/eco-scripts/abi_manager.js
@@ -81,10 +81,6 @@ function updateAllABIDependencies(jsonABI){
                     $("#contractparamnamesjs")[0].value = "no parameters";
 
                 // set invoke params to many empty strings (at least one is desirable for now)
-                // JS
-                $("#cbx_usearray_js")[0].checked = false;
-                if (paramhex == "0710") // enable array passing
-                    $("#cbx_usearray_js")[0].checked = true;
                 updateArrayInvokeParamsJs(); // update auxiliary check boxes
                 updateInvokeParamsJs(); // update simple example
 


### PR DESCRIPTION
Every time a contract is compiled the value of the "use param array" is reset, this is annoying when testing contracts because it means setting it again every time. This PR removes that behaviour.