### PR TITLE
Update build process to include 2.9.3 compiler

### DIFF
--- a/docker-sock-express-compilers/docker-compilers/buildCompilers.sh
+++ b/docker-sock-express-compilers/docker-compilers/buildCompilers.sh
@@ -5,7 +5,7 @@ source .env
 
 if (($BUILD_CSHARP)); then
 	echo "BUILDING BUILDING mono-neo-compiler $BUILD_CSHARP"
-	(cd compilers/docker-compiler-csharp; ./docker_build.sh)
+	(cd compilers/docker-compiler-csharp; ./docker_build.sh; ./docker_build_list_of_compilers.sh)
 else
 	echo "SKIPING BUILDING mono-neo-compiler $BUILD_CSHARP";
 fi


### PR DESCRIPTION
Currently `buildCompilers.sh` only builds the 2.9.4-dev compiler, and the shell script that builds 2.9.3 is not run, thus the latest update to the docker images hasn't been applied to the 2.9.3 compiler image, which at the moment cannot be used from the frontend because it doesn't decompress the contract.

Note that in `docker_build_list_of_compilers.sh` the line that builds the docker image has been commented, I'm not sure what's the reason behind it so I've left it commented:
```
#docker build $ARGS -t docker-mono-neo-compiler:$COMPILER_VERSION .
```